### PR TITLE
platform/miyoo: Fix CI build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -109,7 +109,7 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/dingux-mips32.yml'
 
-  # OpenDingux
+  # OpenDingux (ARM)
   - project: 'libretro-infrastructure/ci-templates'
     file: '/dingux-arm32.yml'
 
@@ -309,8 +309,8 @@ libretro-build-rs90-odbeta-mips32:
     - .libretro-rs90-odbeta-mips32-make-default
     - .core-defs
 
-# OpenDingux
-libretro-build-dingux-arm32:
+# Miyoo
+libretro-build-miyoo-arm32:
   extends:
     - .libretro-miyoo-arm32-make-default
     - .core-defs

--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -499,6 +499,7 @@ else ifeq ($(platform), xbox360_msvc2010)
 	CFLAGS   += -D_XBOX -D_XBOX360
 	CXXFLAGS += -D_XBOX -D_XBOX360
 	STATIC_LINKING=1
+
 # MIYOO
 else ifeq ($(platform), miyoo)
 	TARGET := $(TARGET_NAME)_libretro.so
@@ -506,9 +507,8 @@ else ifeq ($(platform), miyoo)
 	SHARED := -shared -Wl,-version-script=link.T
 	CC = /opt/miyoo/usr/bin/arm-linux-gcc
 	AR = /opt/miyoo/usr/bin/arm-linux-ar
-	PLATFORM_DEFINES += -D_GNU_SOURCE
 	CFLAGS += -fomit-frame-pointer -ffast-math -march=armv5te -mtune=arm926ej-s
-	CFLAGS += -fno-common -ftree-vectorize -funswitch-loops
+
 # DOS
 else ifeq ($(platform), dos)
 	TARGET := $(TARGET_NAME)_libretro_$(platform).a


### PR DESCRIPTION
Correct the name of the build so the artifact is stored in the right
location. Also remove unnecessary build options.