### PR TITLE
Add more CPU frequency

### DIFF
--- a/src/libretro.c
+++ b/src/libretro.c
@@ -140,7 +140,7 @@ static struct retro_variable variables[] =
     },
     {
 	"jaxe_cpu_requency",
-	"CPU frequency; 1000|1500|2000|3000|5000|10000|800|750|600|500|400|300",
+	"CPU frequency; 1000|1500|2000|3000|5000|10000|25000|50000|100000|800|750|600|500|400|300",
     },
     {
 	"jaxe_theme",


### PR DESCRIPTION
With some games, for example The Binding of COSMAC
https://johnearnest.github.io/chip8Archive/play.html?p=binding

The value of the cpu frequency variable is too low, even the value 10000.
I have added several more values, 25000, 50000 and 100000

I include a link to a video with the mentioned game at different CPU frequency speeds
https://streamable.com/jis02v
