### PR TITLE
libretro: Fix ios-arm64/tvos-arm64 toolchain setup

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -63,6 +63,9 @@ else ifeq ($(platform), tvos-arm64)
 	ifeq ($(IOSSDK),)
 		IOSSDK := $(shell xcodebuild -version -sdk appletvos Path)
 	endif
+	CFLAGS   += -arch arm64 -isysroot $(IOSSDK)
+	CXXFLAGS += -arch arm64 -isysroot $(IOSSDK)
+	LDFLAGS  += -arch arm64 -isysroot $(IOSSDK)
 else ifneq (,$(findstring osx,$(platform)))
 	TARGET := $(TARGET_NAME)_libretro.dylib
 	fpic := -fPIC
@@ -80,13 +83,19 @@ else ifneq (,$(findstring ios,$(platform)))
 	fpic := -fPIC
 	SHARED := -dynamiclib
 
-ifeq ($(IOSSDK),)
-	IOSSDK := $(shell xcodebuild -version -sdk iphoneos Path)
-endif
+	ifeq ($(IOSSDK),)
+		IOSSDK := $(shell xcodebuild -version -sdk iphoneos Path)
+	endif
 
-DEFINES := -DIOS
-CC = cc -arch armv7 -isysroot $(IOSSDK)
-LD = cc -arch armv7 -isysroot $(IOSSDK)
+	DEFINES := -DIOS
+	ifeq ($(platform),ios-arm64)
+		CFLAGS   += -arch arm64 -isysroot $(IOSSDK)
+		CXXFLAGS += -arch arm64 -isysroot $(IOSSDK)
+		LDFLAGS  += -arch arm64 -isysroot $(IOSSDK)
+	else
+		CC = cc -arch armv7 -isysroot $(IOSSDK)
+		LD = cc -arch armv7 -isysroot $(IOSSDK)
+	endif
 
 ifeq ($(platform),ios9)
 	CC	+= -miphoneos-version-min=8.0


### PR DESCRIPTION
Also iOS was assuming ios9 (armv7) only.