### PR TITLE
ci: add Linux aarch64 libretro build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -47,6 +47,10 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-i686.yml'
 
+  # Linux ARM 64-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/linux-aarch64.yml'
+
   # MacOS 64-bit
   - project: 'libretro-infrastructure/ci-templates'
     file: '/osx-x64.yml'
@@ -183,6 +187,12 @@ libretro-build-linux-x64:
 libretro-build-linux-i686:
   extends:
     - .libretro-linux-i686-make-default
+    - .core-defs
+
+# Linux ARM 64-bit
+libretro-build-linux-aarch64:
+  extends:
+    - .libretro-linux-aarch64-make-default
     - .core-defs
 
 # MacOS 64-bit


### PR DESCRIPTION
Adds a Linux ARM 64-bit job to the GitLab CI so the libretro buildbot produces an aarch64 build of this core, which is currently missing from https://buildbot.libretro.com/nightly/linux/aarch64/latest/ .

No Makefile changes were needed. The interpreter is plain C99 with no SIMD or JIT, and every `-march` flag in `Makefile.libretro` is gated behind a specific platform (Switch, ARMv7, 3DS, MIPS). arm64 is already exercised by the existing `osx-arm64`, `ios-arm64` and `tvos-arm64` jobs.

Verified locally on an aarch64 Linux machine (postmarketOS, glibc, GCC 15): `jaxe_libretro.so` builds warning-clean, loads in RetroArch 1.22.2, and runs `roms/chip8archive/br8kout.ch8` correctly at 128x64.